### PR TITLE
Use conventional naming for action constants

### DIFF
--- a/build/actions.js
+++ b/build/actions.js
@@ -7,24 +7,24 @@ exports.setLocale = exports.SET_LOCALE = exports.loadTranslations = exports.LOAD
 
 var _index = require('./index');
 
-var LOAD_TRANSLATIONS = exports.LOAD_TRANSLATIONS = 'loadTranslation';
+var LOAD_TRANSLATIONS = exports.LOAD_TRANSLATIONS = '@@i18n/LOAD_TRANSLATIONS';
 var loadTranslations = exports.loadTranslations = function loadTranslations(translations) {
   return function (dispatch) {
-    _index.I18n.forceComponentsUpdate();
     dispatch({
       type: LOAD_TRANSLATIONS,
       translations: translations
     });
+    _index.I18n.forceComponentsUpdate();
   };
 };
 
-var SET_LOCALE = exports.SET_LOCALE = 'setLocal';
+var SET_LOCALE = exports.SET_LOCALE = '@@i18n/SET_LOCALE';
 var setLocale = exports.setLocale = function setLocale(locale) {
   return function (dispatch) {
-    _index.I18n.forceComponentsUpdate();
     dispatch({
       type: SET_LOCALE,
       locale: locale
     });
+    _index.I18n.forceComponentsUpdate();
   };
 };

--- a/src/actions.js
+++ b/src/actions.js
@@ -1,6 +1,6 @@
 import { I18n } from './index';
 
-export const LOAD_TRANSLATIONS = 'loadTranslation';
+export const LOAD_TRANSLATIONS = '@@i18n/LOAD_TRANSLATIONS';
 export const loadTranslations = translations => dispatch => {
   dispatch({
     type: LOAD_TRANSLATIONS,
@@ -9,7 +9,7 @@ export const loadTranslations = translations => dispatch => {
   I18n.forceComponentsUpdate();
 };
 
-export const SET_LOCALE = 'setLocal';
+export const SET_LOCALE = '@@i18n/SET_LOCALE';
 export const setLocale = locale => dispatch => {
   dispatch({
     type: SET_LOCALE,


### PR DESCRIPTION
Hi,

As action types appears in redux debugger it's preferable by convention to have all uppercase action name to show in logs.

Regards!